### PR TITLE
Fix bug (append instead of overwrite) and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# LanceDB: Full-text and vector search
+# LanceDB: A study on full-text, SQL and vector search performance
 
-[LanceDB](https://github.com/lancedb/lancedb) is an embedded (serverless), zero management overhead, developer-friendly and open source vector DB that serves as an alternative to a host of client-server vector DBs currently in the market. Some key features about LanceDB that make it extremely interesting are listed below, among many others on their GitHub repo.
+[LanceDB](https://github.com/lancedb/lancedb) is an embedded (serverless), developer-friendly and open source vector DB that serves as an alternative to a host of client-server vector DBs currently in the market. Some key features about LanceDB that make it extremely interesting are listed below, among many others listed on their GitHub repo.
 
-* Incredibly lightweight (no DB servers to manage), because it runs entirely in-process with your application
+* Incredibly lightweight (no DB servers to manage), because it runs entirely in-process with the application
 * Extremely scalable from development to production
-* Ability to perform both full-text search (FTS), SQL search (via [DataFusion](https://github.com/apache/arrow-datafusion)) and ANN vector search
-* Multi-modal data support (images, text, video, audio, point-clouds, etc)
-* Zero-copy (via Arrow) with automatic versioning of data on its native [Lance](https://github.com/lancedb/lance) storage format
+* Ability to perform full-text search (FTS), SQL search (via [DataFusion](https://github.com/apache/arrow-datafusion)) *and* ANN vector search
+* Multi-modal data support (images, text, video, audio, point-clouds, etc.)
+* Zero-copy (via [Arrow](https://github.com/apache/arrow-rs)) with automatic versioning of data on its native [Lance](https://github.com/lancedb/lance) storage format
 
-The aim of this repo is to go over the FTS and vector search features of LanceDB on a text dataset of Wine reviews, and also study some performance numbers on query performance.
+The aim of this repo is to go over the full-text, SQL and vector search features of LanceDB on a text dataset of Wine reviews, and also to study query performance and throughput.
 
 ## Dataset
 

--- a/lancedb/README.md
+++ b/lancedb/README.md
@@ -20,7 +20,7 @@ SentenceBERT | `sentence-transformers/all-MiniLM-L12-v2` | 384 | 256
 SentenceBERT | `sentence-transformers/all-MiniLM-L6-v2` | 384 | 256
 
 
-#### Ingest data and create FTS and ANN indexes
+### Ingest data and create FTS and ANN indexes
 
 ```sh
 # Build FTS and ANN index with 4 workers for generating embeddings
@@ -32,8 +32,60 @@ python index.py --workers 4
 python index.py --refresh --workers 4
 ```
 
-#### Run sample FTS and vector search queries
+Some example timing numbers (on an M2 Macbook Pro) are shown below:
+
+```sh
+Validated data using Pydantic in 0.8486 sec
+Created sentence embeddings in 2013.6714 sec
+Creating ANN index...
+Created ANN index in 4.2722 sec
+Created FTS index in 0.3027 sec
+Finished execution!
+python index.py --refresh  8487.34s user 1995.44s system 518% cpu 33:42.37 total
+```
+
+The full dataset of ~130K records are ingested in ~33 minutes, with the ANN index taking just 4 seconds to build and the FTS index taking ~0.3 seconds to build. As always, generating the embeddings is the most time-consuming step!
+
+### Run sample FTS and vector search queries
 
 ```sh
 python query.py
 ```
+
+The full text search (via BM25 keyword matches) and vector search (via cosine similarity) results are shown below.
+
+```
+Full-text search result: shape: (10, 17)
+┌────────┬────────┬───────────────────────────────────┬───────────────────────────────────┬───┬───────────────────────┬───────────────────────────────────┬───────────────────────────────────┬──────────┐
+│ id     ┆ points ┆ title                             ┆ description                       ┆ … ┆ taster_twitter_handle ┆ to_vectorize                      ┆ vector                            ┆ score    │
+│ ---    ┆ ---    ┆ ---                               ┆ ---                               ┆   ┆ ---                   ┆ ---                               ┆ ---                               ┆ ---      │
+│ i64    ┆ i64    ┆ str                               ┆ str                               ┆   ┆ str                   ┆ str                               ┆ array[f32, 384]                   ┆ f64      │
+╞════════╪════════╪═══════════════════════════════════╪═══════════════════════════════════╪═══╪═══════════════════════╪═══════════════════════════════════╪═══════════════════════════════════╪══════════╡
+│ 125527 ┆ 88     ┆ Robert Renzoni 2016 Julia's Vine… ┆ This is a fruity, tropical rendi… ┆ … ┆ @mattkettmann         ┆ Pinot Grigio Robert Renzoni 2016… ┆ [-0.001237, 0.021784, … 0.041974… ┆ 5.901485 │
+│ 127601 ┆ 83     ┆ Banrock Station 2001 Chardonnay … ┆ Good party Chard. Nothing too co… ┆ … ┆ @JoeCz                ┆ Chardonnay Banrock Station 2001 … ┆ [-0.020877, -0.015568, … 0.02873… ┆ 5.841707 │
+│ 125136 ┆ 86     ┆ Pride Mountain 2010 Viognier (So… ┆ This is a powerful wine, almost … ┆ … ┆ null                  ┆ Viognier Pride Mountain 2010 Vio… ┆ [-0.000642, -0.016708, … 0.03495… ┆ 5.580855 │
+│ 129608 ┆ 84     ┆ Castle Rock 2010 Chardonnay (Rus… ┆ Too oaky and forward in tropical… ┆ … ┆ null                  ┆ Chardonnay Castle Rock 2010 Char… ┆ [-0.030962, -0.0411, … 0.00888]   ┆ 5.421664 │
+│ …      ┆ …      ┆ …                                 ┆ …                                 ┆ … ┆ …                     ┆ …                                 ┆ …                                 ┆ …        │
+│ 126170 ┆ 88     ┆ Valle dell'Acate 2013 Zagra Gril… ┆ It opens with pretty aromas of o… ┆ … ┆ @kerinokeefe          ┆ Grillo Valle dell'Acate 2013 Zag… ┆ [-0.022173, 0.026167, … 0.020694… ┆ 5.3706   │
+│ 126410 ┆ 86     ┆ Justin 2012 Chardonnay (Central … ┆ Although Chardonnay might not tr… ┆ … ┆ null                  ┆ Chardonnay Justin 2012 Chardonna… ┆ [0.001362, -0.034199, … 0.032258… ┆ 5.3706   │
+│ 128804 ┆ 85     ┆ Tenute Orestiadi 2016 Molino a V… ┆ Tropical fruit aromas meld with … ┆ … ┆ @kerinokeefe          ┆ Grillo Tenute Orestiadi 2016 Mol… ┆ [-0.011769, 0.060849, … 0.02716]  ┆ 5.320488 │
+│ 129690 ┆ 87     ┆ Passaggio 2011 New Generation Un… ┆ Vanilla cream, honey and tropica… ┆ … ┆ null                  ┆ Chardonnay Passaggio 2011 New Ge… ┆ [-0.013895, -0.014257, … 0.00822… ┆ 5.271303 │
+└────────┴────────┴───────────────────────────────────┴───────────────────────────────────┴───┴───────────────────────┴───────────────────────────────────┴───────────────────────────────────┴──────────┘
+Vector search result: shape: (10, 17)
+┌────────┬────────┬───────────────────────────────────┬───────────────────────────────────┬───┬───────────────────────┬───────────────────────────────────┬───────────────────────────────────┬───────────┐
+│ id     ┆ points ┆ title                             ┆ description                       ┆ … ┆ taster_twitter_handle ┆ to_vectorize                      ┆ vector                            ┆ _distance │
+│ ---    ┆ ---    ┆ ---                               ┆ ---                               ┆   ┆ ---                   ┆ ---                               ┆ ---                               ┆ ---       │
+│ i64    ┆ i64    ┆ str                               ┆ str                               ┆   ┆ str                   ┆ str                               ┆ array[f32, 384]                   ┆ f32       │
+╞════════╪════════╪═══════════════════════════════════╪═══════════════════════════════════╪═══╪═══════════════════════╪═══════════════════════════════════╪═══════════════════════════════════╪═══════════╡
+│ 125367 ┆ 88     ┆ Trapiche 2016 Costa & Pampa Char… ┆ This blend of coastal and desert… ┆ … ┆ @wineschach           ┆ Chardonnay Trapiche 2016 Costa &… ┆ [-0.012717, -0.000868, … 0.02559… ┆ 0.27347   │
+│ 129111 ┆ 87     ┆ Palamà 2012 Mavro Negroamaro (Sa… ┆ Made with Negroamaro, this offer… ┆ … ┆ @kerinokeefe          ┆ Negroamaro Palamà 2012 Mavro Neg… ┆ [-0.027401, 0.019011, … 0.032753… ┆ 0.27694   │
+│ 129487 ┆ 88     ┆ Herdade Grande 2012 Colheita Sel… ┆ This fruity wine boasts flavors … ┆ … ┆ @vossroger            ┆ Portuguese White Herdade Grande … ┆ [-0.011832, -0.017191, … 0.04267… ┆ 0.277972  │
+│ 127491 ┆ 85     ┆ Domaines Barons de Rothschild (L… ┆ Aromas of pineapple, lemon and s… ┆ … ┆ @wineschach           ┆ Chardonnay Domaines Barons de Ro… ┆ [-0.018693, -0.015425, … 0.02040… ┆ 0.278787  │
+│ …      ┆ …      ┆ …                                 ┆ …                                 ┆ … ┆ …                     ┆ …                                 ┆ …                                 ┆ …         │
+│ 126003 ┆ 84     ┆ Casal do Conde 2013 White (Tejo)  ┆ This blend of Sauvignon Blanc an… ┆ … ┆ @vossroger            ┆ Portuguese White Casal do Conde … ┆ [-0.012546, 0.001385, … 0.039636… ┆ 0.292588  │
+│ 128181 ┆ 86     ┆ Ochoa 2016 Calendas Garnacha Ros… ┆ Clean nectarine and red plum aro… ┆ … ┆ @wineschach           ┆ Rosado Ochoa 2016 Calendas Garna… ┆ [-0.038352, -0.027079, … 0.00070… ┆ 0.293419  │
+│ 126929 ┆ 87     ┆ Paul Prieur et Fils 2014  Sancer… ┆ In this soft, ripe wine, rounded… ┆ … ┆ @vossroger            ┆ Sauvignon Blanc Paul Prieur et F… ┆ [-0.033548, 0.005416, … 0.035486… ┆ 0.293846  │
+│ 126489 ┆ 86     ┆ Domaine Cheysson 2011  Chirouble… ┆ Emphasizing tannins and tight st… ┆ … ┆ @vossroger            ┆ Gamay Domaine Cheysson 2011  Chi… ┆ [-0.021621, -0.011956, … 0.03878… ┆ 0.294202  │
+└────────┴────────┴───────────────────────────────────┴───────────────────────────────────┴───┴───────────────────────┴───────────────────────────────────┴───────────────────────────────────┴───────────┘
+```
+

--- a/lancedb/index.py
+++ b/lancedb/index.py
@@ -90,7 +90,7 @@ def ingest_batches(tbl: str, validated_data: list[JsonBlob]) -> Table:
     """Ingest batches of data for full-text index"""
     chunked_data = chunk_iterable(validated_data, CHUNKSIZE)
     for i, chunk in enumerate(chunked_data, 1):
-        tbl.add(chunk, mode="overwrite")
+        tbl.add(chunk, mode="append")
 
 
 def embed_batches(tbl: str, validated_data: list[JsonBlob]) -> Table:
@@ -127,7 +127,6 @@ def main(tbl: Table, data: list[JsonBlob]) -> None:
 if __name__ == "__main__":
     # fmt: off
     parser = argparse.ArgumentParser("Bulk index database from the wine reviews JSONL data")
-    parser.add_argument("--refresh", action="store_true", help="Whether to delete existing the database and create a new one")
     parser.add_argument("--limit", "-l", type=int, default=0, help="Limit the size of the dataset to load for testing purposes")
     parser.add_argument("--chunksize", type=int, default=1000, help="Size of each chunk to break the dataset into before processing")
     parser.add_argument("--filename", type=str, default="winemag-data-130k-v2.jsonl.gz", help="Name of the JSONL zip file to use")
@@ -148,7 +147,7 @@ if __name__ == "__main__":
 
     DB_NAME = "./winemag"
     TABLE = "wines"
-    if REFRESH and os.path.exists(DB_NAME):
+    if os.path.exists(DB_NAME):
         shutil.rmtree(DB_NAME)
 
     db = lancedb.connect(DB_NAME)

--- a/lancedb/index.py
+++ b/lancedb/index.py
@@ -99,7 +99,7 @@ def embed_batches(tbl: str, validated_data: list[JsonBlob]) -> Table:
     with ProcessPoolExecutor(max_workers=WORKERS) as executor:
         print(f"Adding vectors to table for ANN index...")
         for i, batch in enumerate(executor.map(vectorize_text, chunked_data), 1):
-            tbl.add(batch, mode="overwrite")
+            tbl.add(batch, mode="append")
             print(f"Finished inserting batch {i} to {tbl.name} table")
 
 
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser("Bulk index database from the wine reviews JSONL data")
     parser.add_argument("--refresh", action="store_true", help="Whether to delete existing the database and create a new one")
     parser.add_argument("--limit", "-l", type=int, default=0, help="Limit the size of the dataset to load for testing purposes")
-    parser.add_argument("--chunksize", type=int, default=5000, help="Size of each chunk to break the dataset into before processing")
+    parser.add_argument("--chunksize", type=int, default=1000, help="Size of each chunk to break the dataset into before processing")
     parser.add_argument("--filename", type=str, default="winemag-data-130k-v2.jsonl.gz", help="Name of the JSONL zip file to use")
     parser.add_argument("--workers", type=int, default=4, help="Number of workers to use for vectorization")
     args = vars(parser.parse_args())

--- a/lancedb/index.py
+++ b/lancedb/index.py
@@ -99,8 +99,8 @@ def embed_batches(tbl: str, validated_data: list[JsonBlob]) -> Table:
     with ProcessPoolExecutor(max_workers=WORKERS) as executor:
         print(f"Adding vectors to table for ANN index...")
         for i, batch in enumerate(executor.map(vectorize_text, chunked_data), 1):
+            print(f"Inserting batch {i} to {tbl.name} table")
             tbl.add(batch, mode="append")
-            print(f"Finished inserting batch {i} to {tbl.name} table")
 
 
 def main(tbl: Table, data: list[JsonBlob]) -> None:

--- a/lancedb/index.py
+++ b/lancedb/index.py
@@ -139,7 +139,6 @@ if __name__ == "__main__":
     FILENAME = args["filename"]
     CHUNKSIZE = args["chunksize"]
     WORKERS = args["workers"]
-    REFRESH = args["refresh"]
 
     data = list(get_json_data(DATA_DIR, FILENAME))
     assert data, "No data found in the specified file"


### PR DESCRIPTION
- Batch size of 1000 makes more sense as 4 concurrent workers are doing the job
- Ingesting the vectors into the table in `overwrite` mode will throw away all the previous vectors -- this isn't intended, and the vectors need to instead be appended
- Docs are now clearer with example outputs