### PR TITLE
Add rich progress bar for vectorization step

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv>=1.0.0
 srsly>=2.4.6
 polars~=0.19.0
 codetiming~=1.4.0
+rich~=13.6.0


### PR DESCRIPTION
Adding a `rich` progress bar to show elapsed time during vectorization and indicate how many batches have been processed.

![image](https://github.com/prrao87/lancedb-study/assets/35005448/f6d4c087-e080-45b4-b750-521a111905bf)
