### PR TITLE
Avoid wasteful serialization/deserialization

### DIFF
--- a/elasticsearch/app.py
+++ b/elasticsearch/app.py
@@ -6,11 +6,11 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from functools import lru_cache
 
-from elasticsearch import AsyncElasticsearch
-from fastapi import FastAPI, HTTPException, Query, Request
-
 from config import Settings
+from fastapi import FastAPI, HTTPException, Query, Request
 from schemas.wine import FullTextSearchModel
+
+from elasticsearch import AsyncElasticsearch
 
 
 @lru_cache()

--- a/elasticsearch/schemas/wine.py
+++ b/elasticsearch/schemas/wine.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+
 class Wine(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,

--- a/lancedb/index.py
+++ b/lancedb/index.py
@@ -6,17 +6,17 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator
 
-import lancedb
 import srsly
 from codetiming import Timer
+from config import Settings
 from dotenv import load_dotenv
-from lancedb.pydantic import pydantic_to_schema
-from lancedb.table import Table
 from rich import progress
+from schemas.wine import LanceModelWine, Wine
 from sentence_transformers import SentenceTransformer
 
-from config import Settings
-from schemas.wine import LanceModelWine, Wine
+import lancedb
+from lancedb.pydantic import pydantic_to_schema
+from lancedb.table import Table
 
 load_dotenv()
 # Custom types

--- a/lancedb/query.py
+++ b/lancedb/query.py
@@ -1,8 +1,8 @@
-import lancedb
 import polars as pl
+from config import Settings
 from sentence_transformers import SentenceTransformer
 
-from config import Settings
+import lancedb
 
 
 def embed_func(text: str, model) -> list[float]:
@@ -16,8 +16,7 @@ def fts(query: str) -> None:
         tbl.search(query, vector_column_name="to_vectorize")
         .select(["id", "title", "description", "points", "price"])
         .limit(10000)
-        .to_arrow()
-    )
+    ).to_arrow()
     df = pl.from_arrow(res).sort("points", descending=True).limit(10)
     # fmt: on
     print(f"Full-text search result\n{df}")
@@ -32,8 +31,7 @@ def vector_search(query: str) -> None:
         .nprobes(NUM_PROBES)
         .select(["id", "title", "description", "points", "price"])
         .limit(10)
-        .to_arrow()
-    )
+    ).to_arrow()
     df = pl.from_arrow(res).sort("points", descending=True).limit(10)
     # fmt: on
     print(f"Vector search result\n{df}")

--- a/lancedb/schemas/wine.py
+++ b/lancedb/schemas/wine.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
-from lancedb.pydantic import Vector
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from lancedb.pydantic import Vector, LanceModel
 
 
 class Wine(BaseModel):
@@ -112,27 +113,11 @@ class FullTextSearchModel(BaseModel):
     points: Optional[int]
 
 
-class SimilaritySearchModel(BaseModel):
-    model_config = ConfigDict(
-        extra="ignore",
-        json_schema_extra={
-            "example": {
-                "wineID": 3845,
-                "country": "Italy",
-                "title": "Castellinuzza e Piuca 2010  Chianti Classico",
-                "description": "This gorgeous Chianti Classico boasts lively cherry, strawberry and violet aromas. The mouthwatering palate shows concentrated wild-cherry flavor layered with mint, white pepper and clove. It has fresh acidity and firm tannins that will develop complexity with more bottle age. A textbook Chianti Classico.",
-                "points": 93,
-                "price": 16,
-                "variety": "Red Blend",
-                "winery": "Castellinuzza e Piuca",
-            }
-        },
-    )
-
+class SimilaritySearchModel(LanceModel):
     id: int
     title: str
     description: Optional[str]
     country: Optional[str]
     variety: Optional[str]
-    price: Optional[float]
     points: Optional[int]
+    price: Optional[float]


### PR DESCRIPTION
- We don't need to convert the output of the Lance query builder to a pandas DataFrame and then a dict
- It's much more efficient to just output a pydantic object that FastAPI can natively use