### PR TITLE
Update benchmarks

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -80,8 +80,8 @@ uvicorn app:app --host 0.0.0.0 --port 8000 --reload
 
 The FTS endpoint can be accessed at `http://localhost:8000/fts_search` and the vector search endpoint can be accessed at `http://localhost:8000/vector_search`.
 
-**Make sure that the FastAPI server is running before running the following steps.**
-
+> [!NOTE]
+> Make sure that the FastAPI server is running before running the following steps.
 
 ### Ingest data for indexing
 

--- a/lancedb/README.md
+++ b/lancedb/README.md
@@ -29,7 +29,8 @@ uvicorn app:app --host 0.0.0.0 --port 8000 --reload
 
 The FTS endpoint can be accessed at `http://localhost:8000/fts_search` and the vector search endpoint can be accessed at `http://localhost:8000/vector_search`.
 
-**Make sure that the FastAPI server is running before running the following steps.**
+> [!NOTE]
+> Make sure that the FastAPI server is running before running the following steps.
 
 
 ### Ingest data and create FTS and ANN indexes

--- a/lancedb/app.py
+++ b/lancedb/app.py
@@ -6,7 +6,6 @@ from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from functools import lru_cache
-from pathlib import Path
 
 from config import Settings
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -15,7 +14,7 @@ from sentence_transformers import SentenceTransformer
 
 import lancedb
 
-executor = ThreadPoolExecutor(max_workers=20)
+executor = ThreadPoolExecutor(max_workers=8)
 
 @lru_cache()
 def get_settings():

--- a/lancedb/app.py
+++ b/lancedb/app.py
@@ -14,7 +14,7 @@ from sentence_transformers import SentenceTransformer
 
 import lancedb
 
-executor = ThreadPoolExecutor(max_workers=8)
+executor = ThreadPoolExecutor(max_workers=4)
 
 @lru_cache()
 def get_settings():


### PR DESCRIPTION
* Lowering the number of executor threads to 8: More threads results in slower QPS as there is also a CPU-bound component involved in the embedding/index lookup
* Too many threads (> 8) means they are just waiting around while the CPU-bound portion is executing

Update:
* 4 executor threads seems to be the optimum for performance for lancedb. The idle threads really don't help too much, and in fact, get in each other's way to slow things down for a large number of requests.